### PR TITLE
Modernize ObjectId generation and add tests

### DIFF
--- a/__tests__/genObjectId.test.js
+++ b/__tests__/genObjectId.test.js
@@ -1,0 +1,13 @@
+const { genObjectId } = require('../dist/index.js');
+
+describe('genObjectId', () => {
+  test('returns a 24-character hexadecimal string', () => {
+    const id = genObjectId();
+    expect(id).toMatch(/^[0-9a-f]{24}$/);
+  });
+
+  test('generates unique ids', () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => genObjectId()));
+    expect(ids.size).toBe(1000);
+  });
+});

--- a/bin/oid
+++ b/bin/oid
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../dist/index.js');
+require('../dist/cli.js');

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "npm run build && jest",
     "coverage": "npm test -- --coverage"
   },
   "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,6 @@
+import clipboardy from 'clipboardy';
+import { genObjectId } from './index';
+
+const generatedObjectId = genObjectId();
+clipboardy.writeSync(generatedObjectId);
+console.log(`${generatedObjectId} was copied to the clipboard!`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
-import clipboardy from 'clipboardy';
+import crypto from 'crypto';
 
+/**
+ * Generates a MongoDB ObjectId.
+ *
+ * The first 4 bytes are a Unix timestamp and the remaining 8 bytes
+ * are cryptographically secure random values.
+ */
 export function genObjectId(): string {
   const timestamp = Math.floor(Date.now() / 1000).toString(16);
-  return (
-    timestamp +
-    'xxxxxxxxxxxxxxxx'.replace(/x/g, () => ((Math.random() * 16) | 0).toString(16)).toLowerCase()
-  );
+  const random = crypto.randomBytes(8).toString('hex');
+  return (timestamp + random).toLowerCase();
 }
 
-const generatedObjectId = genObjectId();
-clipboardy.writeSync(generatedObjectId);
-console.log(`${generatedObjectId} was copied to the clipboard!`);
+export default genObjectId;


### PR DESCRIPTION
## Summary
- refactor generator to use `crypto.randomBytes`
- separate CLI from library export
- add Jest tests for ObjectId format and uniqueness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c615dac93483258ddb16f36ed29e4b